### PR TITLE
use http_build_query for query string creation

### DIFF
--- a/src/ScreenshotsCloud.php
+++ b/src/ScreenshotsCloud.php
@@ -26,15 +26,7 @@ class ScreenshotsCloud {
 
 		$domain = defined('SCREENSHOTSCLOUD_DOMAIN')?SCREENSHOTSCLOUD_DOMAIN:'https://api.screenshots.cloud';
 
-		$options = $options?:[];
-
-		$query = [];
-		
-		foreach ($options as $key => $value) {
-			$query[] = $key . '=' . urlencode($value?:0);
-		}
-
-		$queryString = implode('&', $query);
+		$queryString = http_build_query($options);
 
 		$token = hash_hmac("sha1", $queryString, $apiSecret);
 


### PR DESCRIPTION
Use https://www.php.net/manual/en/function.http-build-query.php to build the query string

- well defined behavior
- benefits from updates and bug fixes to PHP in the future
- simplifies the source

what's not to love?